### PR TITLE
deps: Use Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,12 @@ inputs:
   tag:
     description: 'Tag of snapshot to use: current, last or date. (only used for 2.0)'
     required: false
-    default: ''
   location:
     description: 'Location where Open Watcom should be extracted to (default=/opt/watcom or C:\\watcom)'
     required: false
-    default: ''
   environment:
     description: 'Set environment variables (WATCOM + PATH)'
     required: false
-    default: ''
 runs:
   using: 'node20'
   main: 'index.js'

--- a/action.yml
+++ b/action.yml
@@ -11,15 +11,15 @@ inputs:
   tag:
     description: 'Tag of snapshot to use: current, last or date. (only used for 2.0)'
     required: false
-    default: null
+    default: ''
   location:
     description: 'Location where Open Watcom should be extracted to (default=/opt/watcom or C:\\watcom)'
     required: false
-    default: null
+    default: ''
   environment:
     description: 'Set environment variables (WATCOM + PATH)'
     required: false
-    default: true
+    default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Node 16 is deprecated and will be removed sometime around Spring 2024: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Also schema checker says the `defaut` field has to be a string