### PR TITLE
change default location to install Open Watcom to <home directory>/watcom

### DIFF
--- a/.github/workflows/build_test_release.yml
+++ b/.github/workflows/build_test_release.yml
@@ -35,6 +35,11 @@ jobs:
           - "1.9"
           - "2.0"
           - "2.0-64"
+        include:
+        - runner:  macos-latest
+          version: "2.0-64"
+        - runner:  macos-14
+          version: "2.0-64"
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: false
     default: ''
   location:
-    description: 'Location where Open Watcom should be extracted to (default=/opt/watcom or C:\\WATCOM)'
+    description: 'Location where Open Watcom should be extracted to (default=$HOME/watcom or %USERPROFILE%\\WATCOM)'
     required: false
     default: ''
   environment:


### PR DESCRIPTION

it is always writeble subdirectory for all used hosts including OSX
add experimental OSX 64-bit Intel and ARM binaries to enable use of OW cross-compilation on OSX to OW supported target (by example for DOS etc.)