### PR TITLE
correct OSX Intel test to use correct runner image

### DIFF
--- a/.github/workflows/build_test_release.yml
+++ b/.github/workflows/build_test_release.yml
@@ -36,7 +36,7 @@ jobs:
           - "2.0"
           - "2.0-64"
         include:
-        - runner:  macos-latest
+        - runner:  macos-13
           version: "2.0-64"
         - runner:  macos-14
           version: "2.0-64"


### PR DESCRIPTION
macos-latest and macos-14 use same image
change macos-latest to macos-13 to use OSX Intel image